### PR TITLE
Integrate node-barion npm package for Barion API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "barion-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "barion-mcp",
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",
+        "node-barion": "^4.0.0",
         "yargs": "^18.0.0",
         "zod": "^3.25.63",
         "zod-to-json-schema": "^3.24.5"
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@modelcontextprotocol/inspector": "^0.17.0",
         "@types/node": "^22",
+        "@types/node-barion": "^3.1.3",
         "@types/yargs": "^17.0.33",
         "prettier": "^3.6.2",
         "shx": "^0.4.0",
@@ -80,6 +81,21 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -1131,6 +1147,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1168,6 +1205,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node-barion": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/node-barion/-/node-barion-3.1.3.tgz",
+      "integrity": "sha512-PGRZuaBr/NMEtludt0M/BjSF7gK3LUmORNKM05Sgiov9pGKtZhhMBosHq+YUSZGIhLwA5fhb64v7sY3SRC8MRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2542,6 +2586,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/joi": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
+      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2704,6 +2761,39 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-barion": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-barion/-/node-barion-4.0.0.tgz",
+      "integrity": "sha512-O8n/lxbpiX6vuIJu+thKXMXXr0Dh/vMReYNppAFCV068bJVHe+3Vj6MnqTB1tgFmZX2+wnzawf1YFkRfbK3W/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "joi": "17.7.0",
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/node-barion/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -3704,6 +3794,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -3887,6 +3983,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/AronStankovics/barion-mcp/issues",
     "email": "stankovics.aron@gmail.com"
-  },  
+  },
   "bin": {
     "barion-mcp": "dist/index.js"
   },
@@ -28,7 +28,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "jest",
     "inspect": "mcp-inspector node dist/index.js",
-    "prepublishOnly" : "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "ai",
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.0",
+    "node-barion": "^4.0.0",
     "yargs": "^18.0.0",
     "zod": "^3.25.63",
     "zod-to-json-schema": "^3.24.5"
@@ -55,6 +56,7 @@
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.17.0",
     "@types/node": "^22",
+    "@types/node-barion": "^3.1.3",
     "@types/yargs": "^17.0.33",
     "prettier": "^3.6.2",
     "shx": "^0.4.0",

--- a/src/utils/barion-client.ts
+++ b/src/utils/barion-client.ts
@@ -171,68 +171,24 @@ export interface CancelAuthorizationResponse {
   Errors?: BarionError[];
 }
 
+// ============================================================================
+// Import node-barion
+// ============================================================================
+
+import Barion from 'node-barion';
+
+// ============================================================================
+// BarionClient using node-barion
+// ============================================================================
+
 export class BarionClient {
-  private poskey: string;
-  private baseUrl: string;
+  private barion: any;
 
   constructor(poskey: string, environment: 'test' | 'prod' = 'test') {
-    this.poskey = poskey;
-    this.baseUrl =
-      environment === 'prod'
-        ? 'https://api.barion.com'
-        : 'https://api.test.barion.com';
-  }
-
-  private async request<T>(endpoint: string, data: Record<string, unknown>, method: 'POST' | 'GET' = 'POST'): Promise<T> {
-    const params = {
-      POSKey: this.poskey,
-      ...data,
-    };
-
-    let url = `${this.baseUrl}${endpoint}`;
-    let body: string | undefined;
-
-    if (method === 'GET') {
-      // For GET requests, append parameters as query string
-      const queryParams = new URLSearchParams();
-      Object.entries(params).forEach(([key, value]) => {
-        queryParams.append(key, String(value));
-      });
-      url = `${url}?${queryParams.toString()}`;
-      console.error(`[Barion API] GET Request to: ${url}`);
-    } else {
-      // For POST requests, send as JSON body
-      body = JSON.stringify(params);
-      console.error(`[Barion API] POST Request to: ${url}`);
-      console.error(`[Barion API] Payload:`, JSON.stringify(params, null, 2));
-    }
-
-    const response = await fetch(url, {
-      method,
-      headers: method === 'POST' ? {
-        'Content-Type': 'application/json',
-      } : undefined,
-      body,
+    this.barion = new Barion({
+      POSKey: poskey,
+      Environment: environment,
     });
-
-    console.error(`[Barion API] Response status: ${response.status} ${response.statusText}`);
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`[Barion API] Error response body:`, errorText);
-      throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-    }
-
-    const result = await response.json();
-    console.error(`[Barion API] Response body:`, JSON.stringify(result, null, 2));
-
-    // Check for Barion API errors
-    if (result.Errors && result.Errors.length > 0) {
-      console.error(`[Barion API] API Errors:`, result.Errors);
-      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
-    }
-
-    return result as T;
   }
 
   async startPayment(request: StartPaymentRequest): Promise<StartPaymentResponse> {
@@ -263,13 +219,39 @@ export class BarionClient {
       Locale: 'en-US',
     };
 
-    return this.request<StartPaymentResponse>('/v2/Payment/Start', payload);
+    console.error('[Barion API] Starting payment with node-barion');
+    console.error('[Barion API] Payload:', JSON.stringify(payload, null, 2));
+
+    const result = await this.barion.startPayment(payload);
+
+    console.error('[Barion API] Response:', JSON.stringify(result, null, 2));
+
+    // Check for Barion API errors
+    if (result.Errors && result.Errors.length > 0) {
+      console.error(`[Barion API] API Errors:`, result.Errors);
+      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
+    }
+
+    return result as StartPaymentResponse;
   }
 
   async getPaymentState(paymentId: string): Promise<PaymentStateResponse> {
-    return this.request<PaymentStateResponse>('/v2/Payment/GetPaymentState', {
+    console.error('[Barion API] Getting payment state with node-barion');
+    console.error('[Barion API] PaymentId:', paymentId);
+
+    const result = await this.barion.getPaymentState({
       PaymentId: paymentId,
-    }, 'GET');
+    });
+
+    console.error('[Barion API] Response:', JSON.stringify(result, null, 2));
+
+    // Check for Barion API errors
+    if (result.Errors && result.Errors.length > 0) {
+      console.error(`[Barion API] API Errors:`, result.Errors);
+      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
+    }
+
+    return result as PaymentStateResponse;
   }
 
   async finishReservation(request: FinishReservationRequest): Promise<FinishReservationResponse> {
@@ -281,7 +263,20 @@ export class BarionClient {
       })),
     };
 
-    return this.request<FinishReservationResponse>('/v2/Payment/FinishReservation', payload);
+    console.error('[Barion API] Finishing reservation with node-barion');
+    console.error('[Barion API] Payload:', JSON.stringify(payload, null, 2));
+
+    const result = await this.barion.finishReservation(payload);
+
+    console.error('[Barion API] Response:', JSON.stringify(result, null, 2));
+
+    // Check for Barion API errors
+    if (result.Errors && result.Errors.length > 0) {
+      console.error(`[Barion API] API Errors:`, result.Errors);
+      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
+    }
+
+    return result as FinishReservationResponse;
   }
 
   async refundPayment(request: RefundPaymentRequest): Promise<RefundPaymentResponse> {
@@ -292,7 +287,20 @@ export class BarionClient {
       Comment: request.comment || '',
     };
 
-    return this.request<RefundPaymentResponse>('/v2/Payment/Refund', payload);
+    console.error('[Barion API] Refunding payment with node-barion');
+    console.error('[Barion API] Payload:', JSON.stringify(payload, null, 2));
+
+    const result = await this.barion.refundPayment(payload);
+
+    console.error('[Barion API] Response:', JSON.stringify(result, null, 2));
+
+    // Check for Barion API errors
+    if (result.Errors && result.Errors.length > 0) {
+      console.error(`[Barion API] API Errors:`, result.Errors);
+      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
+    }
+
+    return result as RefundPaymentResponse;
   }
 
   async capturePayment(request: CapturePaymentRequest): Promise<CapturePaymentResponse> {
@@ -304,7 +312,20 @@ export class BarionClient {
       })),
     };
 
-    return this.request<CapturePaymentResponse>('/v2/Payment/Capture', payload);
+    console.error('[Barion API] Capturing payment with node-barion');
+    console.error('[Barion API] Payload:', JSON.stringify(payload, null, 2));
+
+    const result = await this.barion.capturePayment(payload);
+
+    console.error('[Barion API] Response:', JSON.stringify(result, null, 2));
+
+    // Check for Barion API errors
+    if (result.Errors && result.Errors.length > 0) {
+      console.error(`[Barion API] API Errors:`, result.Errors);
+      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
+    }
+
+    return result as CapturePaymentResponse;
   }
 
   async cancelAuthorization(request: CancelAuthorizationRequest): Promise<CancelAuthorizationResponse> {
@@ -312,6 +333,19 @@ export class BarionClient {
       PaymentId: request.paymentId,
     };
 
-    return this.request<CancelAuthorizationResponse>('/v2/Payment/CancelAuthorization', payload);
+    console.error('[Barion API] Canceling authorization with node-barion');
+    console.error('[Barion API] Payload:', JSON.stringify(payload, null, 2));
+
+    const result = await this.barion.cancelAuthorization(payload);
+
+    console.error('[Barion API] Response:', JSON.stringify(result, null, 2));
+
+    // Check for Barion API errors
+    if (result.Errors && result.Errors.length > 0) {
+      console.error(`[Barion API] API Errors:`, result.Errors);
+      throw new Error(`Barion API Error: ${result.Errors.map((e: any) => `${e.ErrorCode}: ${e.Title} - ${e.Description}`).join(', ')}`);
+    }
+
+    return result as CancelAuthorizationResponse;
   }
 }


### PR DESCRIPTION
- Install node-barion and @types/node-barion packages
- Replace custom BarionClient implementation with node-barion
- Keep existing interface definitions for compatibility with MCP tools
- Maintain same API surface for payment operations
- All payment methods (startPayment, getPaymentState, finishReservation, refundPayment, capturePayment, cancelAuthorization) now use node-barion internally